### PR TITLE
added a `listids` method for "lazy loading" messages

### DIFF
--- a/src/easyimap/easyimap.py
+++ b/src/easyimap/easyimap.py
@@ -160,21 +160,25 @@ class Imapper(object):
     def unseen(self, limit=10):
         return self.listup(limit, 'UNSEEN')
 
-    def listup(self, limit=10, *criterion):
+    def listids(self, limit=10, *criterion):
         criterion = criterion or ['ALL']
         status, msgs = self._mailer.search(None, *criterion)
         if status == 'OK':
             emailids = msgs[0].split()
             start = min(len(emailids), limit)
-            result = []
-            for num in emailids[-1:-(start + 1):-1]:
-                typ, content = self._mailer.fetch(num, self._fetch_message_parts)
-                if typ == 'OK':
-                    mail = self._parse_email(content[0][1])
-                    result.append((int(num), mail))
-            return result
+            return emailids[-1:-(start + 1):-1]
         else:
             raise Exception("Could not get ALL")
+
+    def listup(self, limit=10, *criterion):
+        emailids = self.listids(limit, criterion)
+        result = []
+        for num in emailids:
+            typ, content = self._mailer.fetch(num, self._fetch_message_parts)
+            if typ == 'OK':
+                mail = self._parse_email(content[0][1])
+                result.append((int(num), mail))
+        return result
 
     def mail(self, id):
         """returns MailObj by specified id"""


### PR DESCRIPTION
I've been using easyimap with over 6k worth of messages, and parsing all of them in `listup` was taking rather long--especially since I only needed to act on ones I'd not yet processed.

`listids` is code from the core of `listup`, but usable on its own. Here's an example:

```
for id in imapper.listids(10):
    if id in processed:
        continue
    else:
        mail = imapper.mail(id)
```

Pseudo code, but hopefully shows the value. :grinning: 
