### PR TITLE
Fixed a bug in _decode_header function

### DIFF
--- a/easyimap/easyimap.py
+++ b/easyimap/easyimap.py
@@ -218,7 +218,8 @@ def _decode_header(data):
         if charset:
             headers.append(unicode(decoded_str, charset))
         else:
-            headers.append(unicode(decoded_str))
+            encoding = chardet.detect(decoded_str)
+            headers.append(unicode(decoded_str, encoding['encoding']))
     return "".join(headers)
 
 


### PR DESCRIPTION
When no encoding is returned by decode_header function, the else clause
needs to detect the encoding of the data, because the subject of an
e-mail can be non ASCII. Just like in _decode_body.