### PR TITLE
Encode decode header/body when have encoding value

### DIFF
--- a/easyimap/easyimap.py
+++ b/easyimap/easyimap.py
@@ -219,7 +219,10 @@ def _decode_header(data):
             headers.append(unicode(decoded_str, charset))
         else:
             encoding = chardet.detect(decoded_str)
-            headers.append(unicode(decoded_str, encoding['encoding']))
+            if encoding.get('encoding'):
+                headers.append(unicode(decoded_str, encoding['encoding']))
+            else:
+                headers.append(decoded_str)
     return "".join(headers)
 
 
@@ -230,7 +233,10 @@ def _decode_body(part):
         body = unicode(payload, charset) if charset else part.get_payload()
     except:
         encoding = chardet.detect(payload)
-        body = unicode(payload, encoding.get('encoding'))
+        if encoding.get('encoding'):
+            body = unicode(payload, encoding['encoding'])
+        else:
+            body = payload
     return body
 
 


### PR DESCRIPTION
Since 46597ec949c52f2c14a7a311de6cdc6746f0554e encode header. But second parameter from unicode is a string, not None

Example:

```python
print message.title
```

Get error tot process unicode:

```python
Traceback (most recent call last):
  File "/home/zikzakmedia/tryton/src/trytond/trytond/ir/cron.py", line 163, in _callback
    getattr(Model, cron.function)(*args)
  File "/home/zikzakmedia/tryton/src/getmail/getmail.py", line 243, in getmail_servers
    cls.get_server_emails(servers)
  File "/home/zikzakmedia/tryton/src/trytond/trytond/model/modelview.py", line 498, in wrapper
    return func(cls, *args, **kwargs)
  File "/home/zikzakmedia/tryton/src/getmail/getmail.py", line 218, in get_server_emails
    attachments=server.attachment)
  File "/home/zikzakmedia/tryton/src/helpdesk/helpdesk.py", line 555, in getmail
    msgsubject = message.title or 'Not subject'
  File "/home/zikzakmedia/tryton/local/lib/python2.7/site-packages/easyimap/easyimap.py", line 31, in title
    return _decode_header(self._message.get('Subject'))
  File "/home/zikzakmedia/tryton/local/lib/python2.7/site-packages/easyimap/easyimap.py", line 222, in _decode_header
    headers.append(unicode(decoded_str, encoding['encoding']))
TypeError: unicode() argument 2 must be string, not None
```